### PR TITLE
feat(api): 拆分文件与目录接口并优化错误处理

### DIFF
--- a/src-server/api/getDirHandler.go
+++ b/src-server/api/getDirHandler.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetDirHandler 专门用于处理目录请求：
+// - 若为目录则返回目录下的文件/文件夹信息（与原 /get 目录逻辑一致）
+// - 若为文件则返回 404
+func GetDirHandler(c *gin.Context) {
+	decodedPath, err := filepath.Abs(filepath.Join(staticPath, c.Param("path")))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to access path"})
+		return
+	}
+
+	fileInfo, err := os.Stat(decodedPath)
+	if os.IsNotExist(err) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Path not found"})
+		return
+	}
+
+	if !fileInfo.IsDir() {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Path is a file"})
+		return
+	}
+
+	files, err := ioutil.ReadDir(decodedPath)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to scan directory"})
+		return
+	}
+
+	var fileDetails []gin.H
+	for _, file := range files {
+		fileDetails = append(fileDetails, gin.H{
+			"name": file.Name(),
+			"size": file.Size(),
+			"type": func() string {
+				if file.IsDir() {
+					return "directory"
+				}
+				return "file"
+			}(),
+			"stats": gin.H{
+				"atimeMs":     file.ModTime().UnixNano() / 1e6,
+				"birthtimeMs": file.ModTime().UnixNano() / 1e6,
+				"ctimeMs":     file.ModTime().UnixNano() / 1e6,
+				"mtimeMs":     file.ModTime().UnixNano() / 1e6,
+			},
+		})
+	}
+	if len(fileDetails) == 0 {
+		c.JSON(http.StatusOK, []gin.H{})
+		return
+	}
+	c.JSON(http.StatusOK, fileDetails)
+}

--- a/src-server/api/getHandler.go
+++ b/src-server/api/getHandler.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"io/ioutil"
+	// removed ioutil
 	"net/http"
 	"os"
 	"path/filepath"
@@ -24,68 +24,40 @@ func GetHandler(c *gin.Context) {
 		return
 	}
 
+	// 当请求路径为文件夹时，返回404
 	if fileInfo.IsDir() {
-		files, err := ioutil.ReadDir(decodedPath)
+		c.JSON(http.StatusNotFound, gin.H{"error": "Path is a directory"})
+		return
+	}
+
+	// 仅处理文件：保持原有文件返回行为
+	if strings.HasSuffix(decodedPath, "index.html") {
+		f, err := os.Open(decodedPath)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to scan directory"})
+			c.Writer.WriteHeader(http.StatusInternalServerError)
+			c.Writer.Write([]byte("Internal Server Error"))
 			return
 		}
-
-		var fileDetails []gin.H
-		for _, file := range files {
-			fileDetails = append(fileDetails, gin.H{
-				"name": file.Name(),
-				"size": file.Size(),
-				"type": func() string {
-					if file.IsDir() {
-						return "directory"
-					}
-					return "file"
-				}(),
-				"stats": gin.H{
-					"atimeMs":     file.ModTime().UnixNano() / 1e6,
-					"birthtimeMs": file.ModTime().UnixNano() / 1e6,
-					"ctimeMs":     file.ModTime().UnixNano() / 1e6,
-					"mtimeMs":     file.ModTime().UnixNano() / 1e6,
-				},
-			})
-		}
-		if len(fileDetails) == 0 {
-			c.JSON(http.StatusOK, []gin.H{})
-		} else {
-			c.JSON(http.StatusOK, fileDetails)
-		}
-	} else {
-		if strings.HasSuffix(decodedPath, "index.html") {
-			f, err := os.Open(decodedPath)
-			if err != nil {
-				c.Writer.WriteHeader(http.StatusInternalServerError)
-				c.Writer.Write([]byte("Internal Server Error"))
-				return
-			}
-			http.ServeContent(c.Writer, c.Request, "index.html", time.Now(), f)
-		} else {
-			// if c.Query("import") != "" {
-			// 	c.Writer.Header().Set("Content-Type", "application/javascript")
-			// }
-			ext := filepath.Ext(decodedPath)
-			switch ext {
-			case ".js":
-			case ".cjs":
-			case ".mjs":
-				c.Writer.Header().Set("Content-Type", "application/javascript")
-			case ".css":
-				c.Writer.Header().Set("Content-Type", "text/css")
-			case ".html":
-				c.Writer.Header().Set("Content-Type", "text/html")
-			case ".json":
-				c.Writer.Header().Set("Content-Type", "application/json")
-			case ".wasm":
-				c.Writer.Header().Set("Content-Type", "application/wasm")
-			default:
-				c.Writer.Header().Set("Content-Type", "application/octet-stream")
-			}
-			c.File(decodedPath)
-		}
+		http.ServeContent(c.Writer, c.Request, "index.html", time.Now(), f)
+		return
 	}
+
+	ext := filepath.Ext(decodedPath)
+	switch ext {
+	case ".js":
+	case ".cjs":
+	case ".mjs":
+		c.Writer.Header().Set("Content-Type", "application/javascript")
+	case ".css":
+		c.Writer.Header().Set("Content-Type", "text/css")
+	case ".html":
+		c.Writer.Header().Set("Content-Type", "text/html")
+	case ".json":
+		c.Writer.Header().Set("Content-Type", "application/json")
+	case ".wasm":
+		c.Writer.Header().Set("Content-Type", "application/wasm")
+	default:
+		c.Writer.Header().Set("Content-Type", "application/octet-stream")
+	}
+	c.File(decodedPath)
 }

--- a/src-server/main.go
+++ b/src-server/main.go
@@ -30,8 +30,10 @@ func main() {
 	router.Use(corsMiddleware())
 
 	router.GET("/query", api.QueryHandler(fsOperateEventCenter))
-	router.GET("/get/*path", api.GetHandler)
-	router.HEAD("/get/*path", api.GetHandler)
+	router.GET("/file/*path", api.GetHandler)
+	router.HEAD("/file/*path", api.GetHandler)
+	// 新增目录专用接口
+	router.GET("/dir/*path", api.GetDirHandler)
 	router.POST("/mkdir/*path", api.MkdirHandler)
 	router.POST("/upload/*path", api.UploadHandler)
 	router.POST("/cut/*path", api.CutHandler(fsOperateEventCenter))

--- a/src/class/VirtualRemoteDirectory.ts
+++ b/src/class/VirtualRemoteDirectory.ts
@@ -36,7 +36,7 @@ export class VirtualRemoteFile extends VirtualFileBase {
     }
 
     get url() {
-        return `${config.api.get}${this.parent.path}${this.name}`
+        return `${config.api.file}${this.parent.path}${this.name}`
     }
 
     async delete(): Promise<boolean> {
@@ -143,7 +143,7 @@ export class VirtualRemoteDirectory extends VirtualDirectoryBase {
     }
 
     get url(): string {
-        return `${config.api.get}${this.path}`
+        return `${config.api.dir}${this.path}`
     }
 
     updateContent(content: (file | directory)[]) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,8 @@ export default {
    baseUrl,
    uploadSizeLimit: 1024 * 1024 * 100,
    api: {
-      get: '/get',
+      file: '/file',
+      dir: '/dir',
       upload: '/upload',
       delete: '/delete',
       query: '/query',

--- a/src/hooks/useMiaoFetchApi.ts
+++ b/src/hooks/useMiaoFetchApi.ts
@@ -59,16 +59,24 @@ const miaoFetchApi = {
       option?: getOption
    ): Promise<getResponse> {
       const { baseUrl, api } = Config
-      const url = `${baseUrl}${api.get}${vDirectory.path}`
+      const url = `${baseUrl}${api.dir}${vDirectory.path}`
       const retry = option?.retry ?? 0
 
       const { miaoFetch } = useMiaoFetch({
          retry
       })
-      const response = await miaoFetch({
-         url
-      })
-      return response.data
+      try {
+         const response = await miaoFetch({
+            url
+         })
+         return response.data
+      } catch (e: any) {
+         // 将404明确定义为“非目录”错误，便于上层处理
+         if (Array.isArray(e) && e[0]?.response?.status === 404) {
+            throw new Error('Not a directory')
+         }
+         throw e
+      }
    },
 
    /**

--- a/src/plugins/miaoDirectory/miaoDirectory.vue
+++ b/src/plugins/miaoDirectory/miaoDirectory.vue
@@ -425,7 +425,7 @@ const handleItemClick = (item: VirtualDirectory | VirtualFile) => {
          if (useablePlugins.length > 0) {
             pluginCenter.usePlugin(useablePlugins[0].key, [], [item])
          } else {
-            openUrl(`${baseUrl}${api.get}${item.path}`)
+            openUrl(`${baseUrl}${api.file}${item.path}`)
          }
       } else if (item.type === 'directory') {
          setCurrentDirectory(item)
@@ -434,7 +434,7 @@ const handleItemClick = (item: VirtualDirectory | VirtualFile) => {
 }
 
 const handleItemDownload = (item: VirtualFile) => {
-   openUrl(`${baseUrl}${api.get}${item.path}`, {
+   openUrl(`${baseUrl}${api.file}${item.path}`, {
       download: item.name
    })
 }


### PR DESCRIPTION
- 将原 `/get` 接口拆分为 `/file` 和 `/dir` 专用接口
- 新增 GetDirHandler 专门处理目录请求，明确区分文件和目录逻辑
- 优化前端接口调用错误处理，明确404为"非目录"错误
- 更新相关配置文件及前端引用路径